### PR TITLE
Add ckeck for Direct3D

### DIFF
--- a/Assets/Resources/Shaders/RayMarching.shader
+++ b/Assets/Resources/Shaders/RayMarching.shader
@@ -45,12 +45,11 @@ Shader "Hidden/Ray Marching"
     {
         Varyings output;
 
-        // Handles vertically-flipped case.
-        float vflip = sign(_MainTex_TexelSize.y);
-
         output.vertex = input.vertex;
         output.uv = input.vertex;
-        output.uv.y = _YAxisRaySign * output.uv.y;
+        #if defined(SHADER_API_D3D11) || defined(SHADER_API_D3D11_9X) || defined(SHADER_API_D3D9)
+        output.uv.y = -output.uv.y;
+        #endif
 
         return output;
     }

--- a/Assets/Resources/Shaders/RayMarching.shader
+++ b/Assets/Resources/Shaders/RayMarching.shader
@@ -13,6 +13,8 @@ Shader "Hidden/Ray Marching"
     #include "UnityCG.cginc"
     #include "UnityGlobalIllumination.cginc"
 
+    float _YAxisRaySign;
+
     struct Input
     {
         float4 vertex : POSITION;
@@ -43,8 +45,12 @@ Shader "Hidden/Ray Marching"
     {
         Varyings output;
 
+        // Handles vertically-flipped case.
+        float vflip = sign(_MainTex_TexelSize.y);
+
         output.vertex = input.vertex;
         output.uv = input.vertex;
+        output.uv.y = _YAxisRaySign * output.uv.y;
 
         return output;
     }

--- a/Assets/Scripts/RayMarching.cs
+++ b/Assets/Scripts/RayMarching.cs
@@ -109,6 +109,7 @@ public class RayMarching : MonoBehaviour
         {
             m_CommandBuffer = new CommandBuffer();
             m_CommandBuffer.name = "Ray Marching";
+            m_CommandBuffer.SetGlobalFloat("_YAxisRaySign", SystemInfo.graphicsDeviceVersion.StartsWith("Direct") ? -1f : 1f);
             m_CommandBuffer.DrawMesh(quad, Matrix4x4.identity, material, 0, 0, null);
 
             camera_.AddCommandBuffer(CameraEvent.AfterGBuffer, m_CommandBuffer);

--- a/Assets/Scripts/RayMarching.cs
+++ b/Assets/Scripts/RayMarching.cs
@@ -109,7 +109,6 @@ public class RayMarching : MonoBehaviour
         {
             m_CommandBuffer = new CommandBuffer();
             m_CommandBuffer.name = "Ray Marching";
-            m_CommandBuffer.SetGlobalFloat("_YAxisRaySign", SystemInfo.graphicsDeviceVersion.StartsWith("Direct") ? -1f : 1f);
             m_CommandBuffer.DrawMesh(quad, Matrix4x4.identity, material, 0, 0, null);
 
             camera_.AddCommandBuffer(CameraEvent.AfterGBuffer, m_CommandBuffer);


### PR DESCRIPTION
The raymarching shader now has a uniform that sets the sign of the y axis of uv of the ray being cast in the pixel shader
In case if Direct3D the rays were directed upside down
