### PR TITLE
Add check for Direct3D

### DIFF
--- a/Assets/Resources/Shaders/RayMarching.shader
+++ b/Assets/Resources/Shaders/RayMarching.shader
@@ -45,6 +45,9 @@ Shader "Hidden/Ray Marching"
 
         output.vertex = input.vertex;
         output.uv = input.vertex;
+#if defined(UNITY_UV_STARTS_AT_TOP)
+        output.uv.y = -input.vertex.y;
+#endif
 
         return output;
     }


### PR DESCRIPTION
The raymarching shader has a check for the rendering API
If Direct3D the vertical ray direction is flipped
